### PR TITLE
Add repo settings and block direct merges to main

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,19 @@
+repository:
+  name: kubeflow-gke-setup
+  description: "Kubeflow on GKE setup and automation. Contains Terraform, scripts, and ML sample app."
+  private: false
+
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      enforce_admins: true
+      restrictions:
+        users: []
+        teams: []
+      required_status_checks:
+        strict: true
+        contexts: []
+      allow_force_pushes: false
+      allow_deletions: false

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -2,6 +2,7 @@ repository:
   name: kubeflow-gke-setup
   description: "Kubeflow on GKE setup and automation. Contains Terraform, scripts, and ML sample app."
   private: false
+  delete_branch_on_merge: true
 
 branches:
   - name: main


### PR DESCRIPTION
This PR adds a .github/settings.yml file to describe the repository and enforce branch protection rules, blocking direct merges to the main branch.