### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   python-check:
     name: Python Check


### PR DESCRIPTION
Potential fix for [https://github.com/idvoretskyi/kubeflow-gke-setup/security/code-scanning/1](https://github.com/idvoretskyi/kubeflow-gke-setup/security/code-scanning/1)

To resolve the issue, add explicit permissions to the workflow file. These permissions should adhere to the principle of least privilege and only allow the workflow access to what is necessary for its tasks. Based on the workflow's steps (e.g., checking code syntax, testing scripts, verifying file existence), the permissions can be set to `contents: read` at the root level of the workflow. This ensures all jobs in the workflow inherit read-only access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
