### PR TITLE
Upgrade Kubeflow to 1.11.0, add GPU support, and optimize costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,105 +1,86 @@
-# Kubeflow on GKE Setup
+# Kubeflow on GKE
 
-Production-grade, cost-optimized deployment of Kubeflow 1.10.0 on Google Kubernetes Engine using Terraform.
+Deploy a production-ready Kubeflow 1.11.0 environment on Google Kubernetes Engine using Terraform. This setup is cost-optimized using Spot VMs and GKE autoscaling.
 
 ## Quick Start
 
-**Prerequisites**: GCP account with billing enabled, `gcloud`, `terraform`, `kubectl` installed.
+### Prerequisites
+- Google Cloud account with billing enabled.
+- `gcloud`, `terraform`, and `kubectl` installed.
 
-```bash
-git clone https://github.com/idvoretskyi/kubeflow-gke-setup.git
-cd kubeflow-gke-setup/terraform
+### Deployment
+1. Clone the repository and navigate to the terraform directory:
+   ```bash
+   git clone https://github.com/idvoretskyi/kubeflow-gke-setup.git
+   cd kubeflow-gke-setup/terraform
+   ```
+2. Configure Google Cloud:
+   ```bash
+   gcloud config set project YOUR_PROJECT_ID
+   gcloud auth application-default login
+   ```
+3. Initialize and deploy:
+   ```bash
+   terraform init
+   terraform apply
+   ```
 
-gcloud config set project YOUR_PROJECT_ID
-gcloud auth application-default login
-
-terraform init
-terraform plan
-terraform apply
-```
-
-Terraform auto-detects your gcloud configuration (project, region, zone).
-
-## What Gets Deployed
-
-- **GKE zonal cluster** with Spot VMs and autoscaling (1-10 nodes)
-- **Kubeflow 1.10.0** with Jupyter, Pipelines, Katib, KServe
-- **Istio 1.19.3** service mesh + **cert-manager 1.13.2**
-- **Security**: private nodes, Workload Identity, least-privilege IAM, shielded nodes
-
-**Estimated cost**: $30-100/month with Spot VMs (60-91% savings vs on-demand).
+## Infrastructure
+- **GKE Cluster**: Zonal cluster with Spot VMs and 1-10 nodes autoscaling.
+- **Kubeflow 1.11.0**: Includes Jupyter, Pipelines, Katib, and KServe.
+- **Service Mesh**: Istio 1.28.0 and cert-manager 1.16.1.
+- **Security**: Private nodes, Workload Identity, and shielded nodes.
+- **Cost**: Estimated $30-100/month (60-91% savings vs on-demand).
 
 ## Configuration
 
-Copy and edit the example tfvars:
-
+Customize the deployment by editing `terraform.tfvars`:
 ```bash
 cp terraform.tfvars.example terraform.tfvars
 ```
-
-Key variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `release_channel` | `RAPID` | GKE release channel (RAPID/REGULAR/STABLE) |
 | `spot_instances` | `true` | Use Spot VMs for cost savings |
-| `enable_private_nodes` | `true` | Private nodes (no public IPs) |
-| `machine_type` | `e2-medium` | Node machine type |
-| `min_node_count` / `max_node_count` | 1 / 5 | Autoscaling range |
+| `enable_private_nodes` | `true` | Deploy nodes without public IPs |
+| `machine_type` | `e2-medium` | GCE instance type for nodes |
+| `min_node_count` / `max_node_count` | 1 / 5 | Node pool autoscaling limits |
+| `enable_gpu` | `false` | Enable a single T4 GPU node |
 
-To allow API access from specific IPs:
+## Accessing the Dashboard
 
-```hcl
-master_authorized_networks = [
-  { cidr_block = "YOUR_IP/32", display_name = "Workstation" }
-]
-```
+The Kubeflow dashboard is not exposed to the public internet by default. Use port forwarding for secure access:
 
-## Usage
+1. Run the access command:
+   ```bash
+   kubectl port-forward -n kubeflow svc/kubeflow-dashboard-svc 8080:80
+   ```
+2. Open `http://localhost:8080` in your browser.
 
+## Running Pipelines
+
+Follow the example in `examples/sample-ml-app`:
 ```bash
-# View outputs (endpoints, kubeconfig command, etc.)
-terraform -chdir=terraform output
-
-# Access Kubeflow dashboard securely via port-forward
-# Get the exact command from Terraform outputs:
-terraform -chdir=terraform output kubeflow_access_command
-
-# Or run directly:
-kubectl port-forward -n kubeflow svc/kubeflow-dashboard-svc 8080:80
-# Then open http://localhost:8080
-
-# Run ML pipelines
-cd examples/sample-ml-app
+cd ../examples/sample-ml-app
 python data_generator.py
 python run_pipeline.py \
     --kubeflow-endpoint http://localhost:8080 \
     --bucket-name your-gcs-bucket \
     --data-file sample_datasets/classification_data.csv
-
-# Destroy
-terraform -chdir=terraform destroy
 ```
 
-## Security
+## Security and Production
 
-### Secure Dashboard Access
+For production environments requiring HTTPS, Google-managed SSL certificates, and Identity-Aware Proxy (IAP), see [terraform/modules/kubeflow/SECURITY.md](terraform/modules/kubeflow/SECURITY.md).
 
-The Kubeflow dashboard is **not exposed to the public internet** by default. Access is via `kubectl port-forward`, which provides:
+## Cleanup
 
-- ✅ **No public exposure** - dashboard only accessible via authenticated kubectl
-- ✅ **Encrypted transit** - kubectl creates an encrypted tunnel to GKE
-- ✅ **Authentication** - requires valid GKE/Google Cloud credentials
-- ✅ **Zero cost** - no load balancer fees
-
-### HTTPS for Production (Optional)
-
-For production deployments requiring HTTPS, see [terraform/modules/kubeflow/SECURITY.md](terraform/modules/kubeflow/SECURITY.md) for:
-- Google-managed SSL certificates
-- HTTPS Ingress configuration
-- Identity-Aware Proxy (IAP) setup
-- Cost and architecture considerations
+To remove all resources and stop billing:
+```bash
+cd terraform
+terraform destroy
+```
 
 ## License
-
-MIT License - see [LICENSE](LICENSE) file.
+MIT License. See [LICENSE](LICENSE) for details.

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,49 +1,39 @@
 # Data sources for dynamic configuration from gcloud
-
 # Get current gcloud project
 data "external" "gcloud_project" {
   program = ["bash", "-c", "echo '{\"project\":\"'$(gcloud config get-value project 2>/dev/null || echo '')'\"}' "]
 }
-
 # Get current gcloud region
 data "external" "gcloud_region" {
   program = ["bash", "-c", "echo '{\"region\":\"'$(gcloud config get-value compute/region 2>/dev/null || echo '')'\"}' "]
 }
-
 # Get current gcloud zone for fallback region detection
 data "external" "gcloud_zone" {
   program = ["bash", "-c", "echo '{\"zone\":\"'$(gcloud config get-value compute/zone 2>/dev/null || echo '')'\"}' "]
 }
-
 # Get current gcloud account for verification
 data "external" "gcloud_account" {
   program = ["bash", "-c", "echo '{\"account\":\"'$(gcloud config get-value account 2>/dev/null || echo '')'\"}' "]
 }
-
 # Local values for processing the gcloud configuration
 locals {
   # Get project from gcloud config or fallback to variable
   detected_project = data.external.gcloud_project.result.project
   project_id       = local.detected_project != "" ? local.detected_project : var.project_id
-
   # Get region from gcloud config or derive from zone or fallback to variable
   detected_region = data.external.gcloud_region.result.region
   detected_zone   = data.external.gcloud_zone.result.zone
-
   # Extract region from zone if region is not set (e.g., us-central1-a -> us-central1)
   region_from_zone = local.detected_zone != "" ? join("-", slice(split("-", local.detected_zone), 0, 2)) : ""
-
   # Priority: explicit region > region from zone > variable
   region = local.detected_region != "" ? local.detected_region : (
     local.region_from_zone != "" ? local.region_from_zone : var.region
   )
-
   # Zone for zonal cluster deployment (required - only zonal clusters supported)
   # Priority: explicit zone variable > detected zone from gcloud > default zone in region
   zone = var.zone != "" ? var.zone : (
     local.detected_zone != "" ? local.detected_zone : "${local.region}-b"
   )
-
   # Account information for verification
   current_account = data.external.gcloud_account.result.account
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,18 +15,15 @@ terraform {
     }
   }
 }
-
 provider "google" {
   project = local.project_id
   region  = local.region
 }
-
 provider "kubernetes" {
   host                   = "https://${module.gke.endpoint}"
   token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
-
 provider "helm" {
   kubernetes = {
     host                   = "https://${module.gke.endpoint}"
@@ -34,40 +31,39 @@ provider "helm" {
     cluster_ca_certificate = base64decode(module.gke.ca_certificate)
   }
 }
-
 data "google_client_config" "default" {}
-
 module "gke" {
   source = "./modules/gke"
-
   # Wait for required APIs to be enabled
-  depends_on = [google_project_service.required_apis]
-
-  project_id   = local.project_id
-  cluster_name = var.cluster_name
-  region       = local.region
-  zone         = local.zone
-
+  depends_on         = [google_project_service.required_apis]
+  project_id         = local.project_id
+  cluster_name       = var.cluster_name
+  region             = local.region
+  zone               = local.zone
   machine_type       = var.machine_type
   preemptible        = var.preemptible
   spot_instances     = var.spot_instances
   min_node_count     = var.min_node_count
   max_node_count     = var.max_node_count
   initial_node_count = var.initial_node_count
+  disk_size_gb       = var.disk_size_gb
+  oauth_scopes       = var.oauth_scopes
 
-  disk_size_gb = var.disk_size_gb
-  oauth_scopes = var.oauth_scopes
+  master_authorized_networks = var.master_authorized_networks
 
   release_channel      = var.release_channel
   enable_private_nodes = var.enable_private_nodes
+
+  # GPU Configuration
+  enable_gpu       = var.enable_gpu
+  gpu_type         = var.gpu_type
+  gpu_count        = var.gpu_count
+  gpu_machine_type = var.gpu_machine_type
 }
-
 module "kubeflow" {
-  source = "./modules/kubeflow"
-  count  = var.deploy_kubeflow ? 1 : 0
-
-  depends_on = [module.gke]
-
+  source       = "./modules/kubeflow"
+  count        = var.deploy_kubeflow ? 1 : 0
+  depends_on   = [module.gke]
   project_id   = local.project_id
   cluster_name = var.cluster_name
   region       = local.region

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -59,6 +59,9 @@ module "gke" {
   gpu_type         = var.gpu_type
   gpu_count        = var.gpu_count
   gpu_machine_type = var.gpu_machine_type
+
+  # Master authorized networks configuration
+  master_authorized_networks = []
 }
 module "kubeflow" {
   source       = "./modules/kubeflow"

--- a/terraform/modules/gke/main.tf
+++ b/terraform/modules/gke/main.tf
@@ -2,32 +2,26 @@ resource "google_container_cluster" "primary" {
   name                = var.cluster_name
   location            = var.zone
   deletion_protection = false
-
   # We can't create a cluster with no node pool defined, but we want to only use
   # separately managed node pools. So we create the smallest possible default
   # node pool and immediately delete it.
   remove_default_node_pool = true
   initial_node_count       = 1
-
   # Enable IP alias for VPC-native networking
   ip_allocation_policy {}
-
   # Enable workload identity
   workload_identity_config {
     workload_pool = "${var.project_id}.svc.id.goog"
   }
-
   # Enable maintenance policy
   maintenance_policy {
     daily_maintenance_window {
       start_time = "03:00"
     }
   }
-
   # Network configuration
   network    = "default"
   subnetwork = "default"
-
   # Private cluster configuration
   dynamic "private_cluster_config" {
     for_each = var.enable_private_nodes ? [1] : []
@@ -37,7 +31,6 @@ resource "google_container_cluster" "primary" {
       master_ipv4_cidr_block  = "10.0.0.0/28"
     }
   }
-
   # Master authorized networks
   dynamic "master_authorized_networks_config" {
     for_each = length(var.master_authorized_networks) > 0 ? [1] : []
@@ -51,14 +44,11 @@ resource "google_container_cluster" "primary" {
       }
     }
   }
-
   release_channel {
     channel = var.release_channel
   }
-
   # Enable shielded nodes
   enable_shielded_nodes = true
-
   # Addons
   addons_config {
     http_load_balancing {
@@ -72,26 +62,22 @@ resource "google_container_cluster" "primary" {
     }
   }
 }
-
 # Create a separately managed node pool for cost optimization
 resource "google_container_node_pool" "primary_nodes" {
   name       = "${var.cluster_name}-nodes"
   location   = var.zone
   cluster    = google_container_cluster.primary.name
   node_count = var.initial_node_count
-
   # Enable autoscaling
   autoscaling {
     min_node_count = var.min_node_count
     max_node_count = var.max_node_count
   }
-
   # Enable auto-upgrade and auto-repair
   management {
     auto_repair  = true
     auto_upgrade = true
   }
-
   node_config {
     # Use Spot VMs (recommended) or preemptible for cost savings (60-91% discount)
     spot            = var.spot_instances
@@ -101,52 +87,108 @@ resource "google_container_node_pool" "primary_nodes" {
     disk_type       = "pd-ssd"
     service_account = google_service_account.gke_node_sa.email
     oauth_scopes    = var.oauth_scopes
-
     # Enable workload identity
     workload_metadata_config {
       mode = "GKE_METADATA"
     }
-
     # Shielded instance config
     shielded_instance_config {
       enable_secure_boot          = true
       enable_integrity_monitoring = true
     }
-
     # Labels for cost tracking
     labels = {
       env         = "kubeflow"
       team        = "ml-platform"
       cost-center = "research"
     }
-
     # Taint to ensure only Kubeflow workloads schedule on these nodes
     taint {
       key    = "kubeflow"
       value  = "true"
       effect = "NO_SCHEDULE"
     }
-
     # Metadata
     metadata = {
       disable-legacy-endpoints = "true"
     }
   }
-
   # Upgrade settings
   upgrade_settings {
     max_surge       = 1
     max_unavailable = 0
   }
 }
+# Separate GPU node pool for ML workloads (cost-optimized with Spot VMs)
+resource "google_container_node_pool" "gpu_nodes" {
+  count              = var.enable_gpu ? 1 : 0
+  name               = "${var.cluster_name}-gpu-nodes"
+  location           = var.zone
+  cluster            = google_container_cluster.primary.name
+  initial_node_count = 0
 
+  # Enable autoscaling to allow scaling down to zero when not in use
+  autoscaling {
+    min_node_count = 0
+    max_node_count = 1
+  }
+
+  # Enable auto-upgrade and auto-repair
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  node_config {
+    spot            = var.spot_instances
+    preemptible     = var.spot_instances ? false : var.preemptible
+    machine_type    = var.gpu_machine_type
+    disk_size_gb    = var.disk_size_gb
+    disk_type       = "pd-ssd"
+    service_account = google_service_account.gke_node_sa.email
+    oauth_scopes    = var.oauth_scopes
+    guest_accelerator {
+      type  = var.gpu_type
+      count = var.gpu_count
+    }
+    # Enable workload identity
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+    # Shielded instance config
+    shielded_instance_config {
+      enable_secure_boot          = true
+      enable_integrity_monitoring = true
+    }
+    # Labels for cost tracking
+    labels = {
+      env         = "kubeflow"
+      team        = "ml-platform"
+      cost-center = "research"
+      gpu         = "true"
+    }
+    # Taint to ensure only GPU-intensive workloads schedule on these nodes
+    taint {
+      key    = "nvidia.com/gpu"
+      value  = "present"
+      effect = "NO_SCHEDULE"
+    }
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+  # Upgrade settings
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+}
 # Service account for GKE nodes
 resource "google_service_account" "gke_node_sa" {
   account_id   = "${var.cluster_name}-node-sa"
   display_name = "GKE Node Service Account for ${var.cluster_name}"
   description  = "Service account for GKE nodes in ${var.cluster_name}"
 }
-
 # IAM bindings for the node service account
 resource "google_project_iam_member" "gke_node_sa_bindings" {
   for_each = toset([
@@ -156,12 +198,10 @@ resource "google_project_iam_member" "gke_node_sa_bindings" {
     "roles/stackdriver.resourceMetadata.writer",
     "roles/storage.objectViewer"
   ])
-
   project = var.project_id
   role    = each.value
   member  = "serviceAccount:${google_service_account.gke_node_sa.email}"
 }
-
 # BigQuery dataset for cost tracking
 resource "google_bigquery_dataset" "gke_usage" {
   dataset_id                  = "${replace(var.cluster_name, "-", "_")}_usage"
@@ -169,7 +209,6 @@ resource "google_bigquery_dataset" "gke_usage" {
   description                 = "Dataset containing GKE resource usage data"
   location                    = "US"
   default_table_expiration_ms = 2592000000 # 30 days
-
   access {
     role          = "OWNER"
     user_by_email = google_service_account.gke_node_sa.email

--- a/terraform/modules/gke/outputs.tf
+++ b/terraform/modules/gke/outputs.tf
@@ -2,38 +2,35 @@ output "cluster_name" {
   description = "Name of the GKE cluster"
   value       = google_container_cluster.primary.name
 }
-
 output "endpoint" {
   description = "Endpoint of the GKE cluster"
   value       = google_container_cluster.primary.endpoint
 }
-
 output "ca_certificate" {
   description = "CA certificate of the GKE cluster"
   value       = google_container_cluster.primary.master_auth[0].cluster_ca_certificate
 }
-
 output "cluster_id" {
   description = "ID of the GKE cluster"
   value       = google_container_cluster.primary.id
 }
-
 output "node_pool_id" {
   description = "ID of the primary node pool"
   value       = google_container_node_pool.primary_nodes.id
 }
-
 output "service_account_email" {
   description = "Email of the GKE node service account"
   value       = google_service_account.gke_node_sa.email
 }
-
 output "cluster_version" {
   description = "Version of the GKE cluster"
   value       = google_container_cluster.primary.master_version
 }
-
 output "node_version" {
   description = "Version of the GKE nodes"
   value       = google_container_node_pool.primary_nodes.version
+}
+output "gpu_node_pool_id" {
+  description = "ID of the GPU node pool"
+  value       = var.enable_gpu ? google_container_node_pool.gpu_nodes[0].id : null
 }

--- a/terraform/modules/gke/variables.tf
+++ b/terraform/modules/gke/variables.tf
@@ -16,7 +16,6 @@ variable "region" {
 variable "zone" {
   description = "GCP zone for the zonal cluster (required). Only zonal clusters are supported for cost optimization."
   type        = string
-
   validation {
     condition     = length(var.zone) > 0
     error_message = "Zone must be specified. Only zonal clusters are supported (e.g., 'us-east1-c')."
@@ -65,7 +64,6 @@ variable "master_authorized_networks" {
     display_name = string
   }))
   default = []
-
   validation {
     condition = alltrue([
       for network in var.master_authorized_networks :
@@ -74,11 +72,9 @@ variable "master_authorized_networks" {
     error_message = "All cidr_block values must be valid CIDR notation (e.g., '203.0.113.0/24')."
   }
 }
-
 # =============================================================================
 # GKE Version and Cluster Configuration
 # =============================================================================
-
 variable "release_channel" {
   description = "GKE release channel: RAPID (latest K8s 1.35), REGULAR (1.33), STABLE (1.33)"
   type        = string
@@ -88,11 +84,37 @@ variable "release_channel" {
 variable "enable_private_nodes" {
   description = "Enable private nodes (no public IPs on nodes). For demo/testing: false (no NAT cost). For production: true (more secure)."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "spot_instances" {
   description = "Use Spot VMs instead of preemptible (newer API, same discount)"
   type        = bool
   default     = true
+}
+# =============================================================================
+# GPU Configuration
+# =============================================================================
+variable "enable_gpu" {
+  description = "Enable a GPU node pool for ML workloads"
+  type        = bool
+  default     = false
+}
+
+variable "gpu_type" {
+  description = "Type of GPU to use (e.g., nvidia-tesla-t4). Cheapest is nvidia-tesla-t4."
+  type        = string
+  default     = "nvidia-tesla-t4"
+}
+
+variable "gpu_count" {
+  description = "Number of GPUs per node"
+  type        = number
+  default     = 1
+}
+
+variable "gpu_machine_type" {
+  description = "Machine type for GPU nodes (must support GPUs, e.g., n1-standard-4). e2 instances do NOT support GPUs."
+  type        = string
+  default     = "n1-standard-4"
 }

--- a/terraform/modules/kubeflow/main.tf
+++ b/terraform/modules/kubeflow/main.tf
@@ -1,8 +1,7 @@
 locals {
-  kubeflow_version  = "1.10.0"
+  kubeflow_version  = "1.11.0"
   kustomize_version = "5.0.1"
 }
-
 # Create namespace for Kubeflow
 resource "kubernetes_namespace_v1" "kubeflow" {
   metadata {
@@ -13,7 +12,6 @@ resource "kubernetes_namespace_v1" "kubeflow" {
     }
   }
 }
-
 resource "kubernetes_namespace_v1" "istio_system" {
   metadata {
     name = "istio-system"
@@ -22,7 +20,6 @@ resource "kubernetes_namespace_v1" "istio_system" {
     }
   }
 }
-
 resource "kubernetes_namespace_v1" "cert_manager" {
   metadata {
     name = "cert-manager"
@@ -31,15 +28,13 @@ resource "kubernetes_namespace_v1" "cert_manager" {
     }
   }
 }
-
 # Install cert-manager using Helm
 resource "helm_release" "cert_manager" {
   name       = "cert-manager"
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = "v1.13.2"
+  version    = "v1.16.1"
   namespace  = kubernetes_namespace_v1.cert_manager.metadata[0].name
-
   set = [
     {
       name  = "installCRDs"
@@ -50,31 +45,25 @@ resource "helm_release" "cert_manager" {
       value = kubernetes_namespace_v1.cert_manager.metadata[0].name
     }
   ]
-
   depends_on = [kubernetes_namespace_v1.cert_manager]
 }
-
 # Install Istio using Helm
 resource "helm_release" "istio_base" {
   name       = "istio-base"
   repository = "https://istio-release.storage.googleapis.com/charts"
   chart      = "base"
-  version    = "1.19.3"
+  version    = "1.28.0"
   namespace  = kubernetes_namespace_v1.istio_system.metadata[0].name
-
   depends_on = [kubernetes_namespace_v1.istio_system]
 }
-
 resource "helm_release" "istiod" {
   name       = "istiod"
   repository = "https://istio-release.storage.googleapis.com/charts"
   chart      = "istiod"
-  version    = "1.19.3"
+  version    = "1.28.0"
   namespace  = kubernetes_namespace_v1.istio_system.metadata[0].name
-
   depends_on = [helm_release.istio_base]
 }
-
 # Local values for Kubeflow manifests - split multi-document YAML files
 locals {
   # Read raw manifest files
@@ -85,7 +74,6 @@ locals {
     katib    = file("${path.module}/manifests/kubeflow-katib.yaml")
     serving  = file("${path.module}/manifests/kubeflow-serving.yaml")
   }
-
   # Split each file by --- and flatten into a list of individual YAML documents
   # Filter out empty documents
   all_manifests = flatten([
@@ -95,20 +83,16 @@ locals {
     ]
   ])
 }
-
 # Install Kubeflow using manifest files
 resource "kubernetes_manifest" "kubeflow_manifests" {
-  count = length(local.all_manifests)
-
+  count    = length(local.all_manifests)
   manifest = yamldecode(local.all_manifests[count.index])
-
   depends_on = [
     kubernetes_namespace_v1.kubeflow,
     helm_release.cert_manager,
     helm_release.istiod
   ]
 }
-
 # Create a service account for Kubeflow
 resource "kubernetes_service_account_v1" "kubeflow_sa" {
   metadata {
@@ -119,14 +103,12 @@ resource "kubernetes_service_account_v1" "kubeflow_sa" {
     }
   }
 }
-
 # Create GCP service account for Kubeflow
 resource "google_service_account" "kubeflow_gcp_sa" {
   account_id   = "${var.cluster_name}-kubeflow-sa"
   display_name = "Kubeflow Service Account for ${var.cluster_name}"
   description  = "Service account for Kubeflow workloads"
 }
-
 # IAM bindings for Kubeflow service account
 # Following principle of least privilege with granular permissions
 resource "google_project_iam_member" "kubeflow_sa_bindings" {
@@ -138,22 +120,18 @@ resource "google_project_iam_member" "kubeflow_sa_bindings" {
     "roles/monitoring.metricWriter", # Unchanged - appropriate for metrics
     "roles/logging.logWriter"        # Unchanged - appropriate for logs
   ])
-
   project = var.project_id
   role    = each.value
   member  = "serviceAccount:${google_service_account.kubeflow_gcp_sa.email}"
 }
-
 # Workload Identity binding
 resource "google_service_account_iam_binding" "kubeflow_workload_identity" {
   service_account_id = google_service_account.kubeflow_gcp_sa.name
   role               = "roles/iam.workloadIdentityUser"
-
   members = [
     "serviceAccount:${var.project_id}.svc.id.goog[${kubernetes_namespace_v1.kubeflow.metadata[0].name}/${kubernetes_service_account_v1.kubeflow_sa.metadata[0].name}]"
   ]
 }
-
 # Create ClusterIP service for Kubeflow Central Dashboard
 # For secure access, use kubectl port-forward instead of public LoadBalancer
 resource "kubernetes_service_v1" "kubeflow_dashboard" {
@@ -164,14 +142,11 @@ resource "kubernetes_service_v1" "kubeflow_dashboard" {
       "app.kubernetes.io/name" = "kubeflow-dashboard"
     }
   }
-
   spec {
     type = "ClusterIP"
-
     selector = {
       "app.kubernetes.io/name" = "centraldashboard"
     }
-
     port {
       port        = 80
       target_port = 8082
@@ -179,18 +154,14 @@ resource "kubernetes_service_v1" "kubeflow_dashboard" {
       name        = "http"
     }
   }
-
   depends_on = [kubernetes_manifest.kubeflow_manifests]
 }
-
 # OPTIONAL: For production deployments with HTTPS, uncomment the configuration below
 # This creates an Ingress with Google-managed SSL certificate
-
 # Uncomment to enable HTTPS access via Ingress
 # resource "google_compute_global_address" "kubeflow_ip" {
 #   name = "${var.cluster_name}-kubeflow-ip"
 # }
-
 # resource "google_compute_managed_ssl_certificate" "kubeflow_cert" {
 #   name = "${var.cluster_name}-kubeflow-cert"
 #
@@ -198,7 +169,6 @@ resource "kubernetes_service_v1" "kubeflow_dashboard" {
 #     domains = [var.domain]  # Set domain variable, e.g., "kubeflow.example.com"
 #   }
 # }
-
 # resource "kubernetes_ingress_v1" "kubeflow_ingress" {
 #   metadata {
 #     name      = "kubeflow-ingress"
@@ -236,17 +206,14 @@ resource "kubernetes_service_v1" "kubeflow_dashboard" {
 #     google_compute_managed_ssl_certificate.kubeflow_cert
 #   ]
 # }
-
 # Create Cloud Storage bucket for Kubeflow artifacts
 resource "google_storage_bucket" "kubeflow_artifacts" {
   name          = "${var.project_id}-kubeflow-artifacts"
   location      = "US"
   force_destroy = true
-
   versioning {
     enabled = true
   }
-
   lifecycle_rule {
     condition {
       age = 30
@@ -255,7 +222,6 @@ resource "google_storage_bucket" "kubeflow_artifacts" {
       type = "Delete"
     }
   }
-
   cors {
     origin          = ["*"]
     method          = ["GET", "HEAD", "PUT", "POST", "DELETE"]
@@ -263,7 +229,6 @@ resource "google_storage_bucket" "kubeflow_artifacts" {
     max_age_seconds = 3600
   }
 }
-
 # Grant storage access to Kubeflow service account
 # Using objectAdmin instead of admin - sufficient for artifact storage operations
 resource "google_storage_bucket_iam_member" "kubeflow_storage_access" {

--- a/terraform/modules/kubeflow/manifests/kubeflow-core.yaml
+++ b/terraform/modules/kubeflow/manifests/kubeflow-core.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: kubeflow
   labels:
     app.kubernetes.io/name: centraldashboard
-    app.kubernetes.io/version: "1.10.0"
+    app.kubernetes.io/version: "1.11.0"
 spec:
   replicas: 1
   selector:
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: centraldashboard
       containers:
       - name: centraldashboard
-        image: kubeflownotebookswg/centraldashboard:v1.10.0
+        image: kubeflownotebookswg/centraldashboard:v1.11.0
         ports:
         - containerPort: 8082
         env:
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
       - name: manager
-        image: kubeflownotebookswg/profile-controller:v1.10.0
+        image: kubeflownotebookswg/profile-controller:v1.11.0
         ports:
         - containerPort: 8080
         env:

--- a/terraform/modules/kubeflow/manifests/kubeflow-katib.yaml
+++ b/terraform/modules/kubeflow/manifests/kubeflow-katib.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: katib-controller
       containers:
       - name: katib-controller
-        image: kubeflowkatib/katib-controller:v0.16.0
+        image: kubeflowkatib/katib-controller:v0.19.0
         ports:
         - containerPort: 8080
         env:
@@ -74,7 +74,7 @@ spec:
     spec:
       containers:
       - name: katib-ui
-        image: kubeflowkatib/katib-ui:v0.16.0
+        image: kubeflowkatib/katib-ui:v0.19.0
         ports:
         - containerPort: 8080
         env:

--- a/terraform/modules/kubeflow/manifests/kubeflow-notebook.yaml
+++ b/terraform/modules/kubeflow/manifests/kubeflow-notebook.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: notebook-controller
       containers:
       - name: manager
-        image: kubeflownotebookswg/notebook-controller:v1.10.0
+        image: kubeflownotebookswg/notebook-controller:v1.11.0
         ports:
         - containerPort: 8443
         env:
@@ -74,7 +74,7 @@ spec:
     spec:
       containers:
       - name: jupyter-web-app
-        image: kubeflownotebookswg/jupyter-web-app:v1.10.0
+        image: kubeflownotebookswg/jupyter-web-app:v1.11.0
         ports:
         - containerPort: 5000
         env:

--- a/terraform/modules/kubeflow/manifests/kubeflow-pipeline.yaml
+++ b/terraform/modules/kubeflow/manifests/kubeflow-pipeline.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: ml-pipeline
       containers:
       - name: ml-pipeline-api-server
-        image: gcr.io/ml-pipeline/api-server:2.0.5
+        image: gcr.io/ml-pipeline/api-server:2.15.0
         ports:
         - containerPort: 8888
         - containerPort: 8887
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
       - name: ml-pipeline-ui
-        image: gcr.io/ml-pipeline/frontend:2.0.5
+        image: gcr.io/ml-pipeline/frontend:2.15.0
         ports:
         - containerPort: 3000
         env:

--- a/terraform/modules/kubeflow/manifests/kubeflow-serving.yaml
+++ b/terraform/modules/kubeflow/manifests/kubeflow-serving.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: kfserving-controller
       containers:
       - name: manager
-        image: kfserving/kfserving-controller:v0.11.2
+        image: kserve/kserve-controller:v0.15.2
         ports:
         - containerPort: 8080
         env:
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
       - name: models-web-app
-        image: kubeflownotebookswg/models-web-app:v1.10.0
+        image: kubeflownotebookswg/models-web-app:v0.15.0
         ports:
         - containerPort: 5000
         env:

--- a/terraform/modules/kubeflow/outputs.tf
+++ b/terraform/modules/kubeflow/outputs.tf
@@ -2,17 +2,14 @@ output "endpoint" {
   description = "Kubeflow dashboard service name (use kubectl port-forward for secure local access)"
   value       = kubernetes_service_v1.kubeflow_dashboard.metadata[0].name
 }
-
 output "port_forward_command" {
   description = "Command to securely access Kubeflow dashboard via kubectl port-forward"
   value       = "kubectl port-forward -n ${kubernetes_namespace_v1.kubeflow.metadata[0].name} svc/${kubernetes_service_v1.kubeflow_dashboard.metadata[0].name} 8080:80"
 }
-
 output "dashboard_url" {
   description = "URL to access Kubeflow dashboard after running port-forward command"
   value       = "http://localhost:8080"
 }
-
 # Uncomment when using HTTPS Ingress configuration in main.tf
 # output "https_endpoint" {
 #   description = "HTTPS endpoint for Kubeflow dashboard"
@@ -23,22 +20,18 @@ output "dashboard_url" {
 #   description = "Static IP address for the Ingress (point your DNS A record to this IP)"
 #   value       = google_compute_global_address.kubeflow_ip.address
 # }
-
 output "kubeflow_namespace" {
   description = "Kubeflow namespace"
   value       = kubernetes_namespace_v1.kubeflow.metadata[0].name
 }
-
 output "service_account_email" {
   description = "Email of the Kubeflow GCP service account"
   value       = google_service_account.kubeflow_gcp_sa.email
 }
-
 output "artifacts_bucket" {
   description = "Name of the Kubeflow artifacts bucket"
   value       = google_storage_bucket.kubeflow_artifacts.name
 }
-
 output "artifacts_bucket_url" {
   description = "URL of the Kubeflow artifacts bucket"
   value       = google_storage_bucket.kubeflow_artifacts.url

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,24 +2,20 @@ output "cluster_name" {
   description = "Name of the GKE cluster"
   value       = module.gke.cluster_name
 }
-
 output "cluster_endpoint" {
   description = "Endpoint of the GKE cluster"
   value       = module.gke.endpoint
   sensitive   = true
 }
-
 output "cluster_ca_certificate" {
   description = "CA certificate of the GKE cluster"
   value       = module.gke.ca_certificate
   sensitive   = true
 }
-
 output "kubeconfig_command" {
   description = "Command to configure kubectl"
   value       = "gcloud container clusters get-credentials ${module.gke.cluster_name} --zone ${local.zone} --project ${local.project_id}"
 }
-
 output "detected_config" {
   description = "Detected gcloud configuration"
   value = {
@@ -29,18 +25,19 @@ output "detected_config" {
     account    = local.current_account
   }
 }
-
 output "kubeflow_access_command" {
   description = "Command to securely access Kubeflow dashboard"
   value       = var.deploy_kubeflow ? module.kubeflow[0].port_forward_command : "Kubeflow not deployed"
 }
-
 output "kubeflow_dashboard_url" {
   description = "Local URL after running port-forward command"
   value       = var.deploy_kubeflow ? module.kubeflow[0].dashboard_url : "Kubeflow not deployed"
 }
-
 output "kubernetes_version" {
   description = "Kubernetes version running on the cluster"
   value       = module.gke.cluster_version
+}
+output "gpu_enabled" {
+  description = "Whether GPU node pool is enabled"
+  value       = var.enable_gpu
 }

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -1,6 +1,5 @@
 # Enable required GCP APIs for Kubeflow deployment
 # These services must be enabled before creating resources
-
 resource "google_project_service" "required_apis" {
   for_each = toset([
     "container.googleapis.com",            # GKE
@@ -13,10 +12,8 @@ resource "google_project_service" "required_apis" {
     "cloudresourcemanager.googleapis.com", # Resource Manager
     "iam.googleapis.com",                  # IAM
   ])
-
-  project = local.project_id
-  service = each.value
-
+  project                    = local.project_id
+  service                    = each.value
   disable_on_destroy         = false
   disable_dependent_services = false
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -14,7 +14,12 @@ spot_instances     = true
 min_node_count     = 1
 max_node_count     = 10
 initial_node_count = 3
-disk_size_gb       = 100
+disk_size_gb       = 50
+
+# GPU Configuration (Optional)
+# enable_gpu       = true
+# gpu_type         = "nvidia-tesla-t4"
+# gpu_machine_type = "n1-standard-4"
 
 # Master authorized networks — uncomment and add your IP to access the K8s API
 # master_authorized_networks = [

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,16 +72,30 @@ variable "oauth_scopes" {
   ]
 }
 
+variable "master_authorized_networks" {
+  description = "List of CIDR blocks authorized to access the Kubernetes master. Leave empty to disable external access to the master endpoint."
+  type = list(object({
+    cidr_block   = string
+    display_name = string
+  }))
+  default = []
+  validation {
+    condition = alltrue([
+      for network in var.master_authorized_networks :
+      can(cidrhost(network.cidr_block, 0))
+    ])
+    error_message = "All cidr_block values must be valid CIDR notation (e.g., '203.0.113.0/24')."
+  }
+}
+
 variable "domain" {
   description = "Domain name for Kubeflow (optional)"
   type        = string
   default     = ""
 }
-
 # =============================================================================
 # GKE Version and Cluster Configuration
 # =============================================================================
-
 variable "release_channel" {
   description = <<-EOT
     GKE release channel for automatic Kubernetes version management.
@@ -91,7 +105,6 @@ variable "release_channel" {
   EOT
   type        = string
   default     = "RAPID"
-
   validation {
     condition     = contains(["RAPID", "REGULAR", "STABLE", "UNSPECIFIED"], var.release_channel)
     error_message = "Release channel must be one of: RAPID, REGULAR, STABLE, UNSPECIFIED."
@@ -114,4 +127,30 @@ variable "deploy_kubeflow" {
   description = "Whether to deploy Kubeflow module"
   type        = bool
   default     = false
+}
+# =============================================================================
+# GPU Configuration
+# =============================================================================
+variable "enable_gpu" {
+  description = "Enable a GPU node pool for ML workloads"
+  type        = bool
+  default     = false
+}
+
+variable "gpu_type" {
+  description = "Type of GPU to use (e.g., nvidia-tesla-t4). Cheapest is nvidia-tesla-t4."
+  type        = string
+  default     = "nvidia-tesla-t4"
+}
+
+variable "gpu_count" {
+  description = "Number of GPUs per node"
+  type        = number
+  default     = 1
+}
+
+variable "gpu_machine_type" {
+  description = "Machine type for GPU nodes (must support GPUs, e.g., n1-standard-4). e2 instances do NOT support GPUs."
+  type        = string
+  default     = "n1-standard-4"
 }


### PR DESCRIPTION
This PR introduces several significant updates to the Kubeflow on GKE setup:

- **Kubeflow Upgrade**: Upgraded core components to version **1.11.0**.
- **Component Updates**:
  - Pipelines: 2.15.0
  - Katib: v0.19.0
  - KServe: v0.15.2
  - Istio: 1.28.0
  - Cert-manager: 1.16.1
- **GPU Support**: Added a configurable GPU node pool (default: disabled) using cost-effective Spot VMs and Tesla T4 GPUs.
- **Cost Optimization**: Reduced default disk size to 50GB and refined resource requests/limits.
- **Documentation**: Simplified README.md and updated configuration examples.

Signed-off-by: Ihor Dvoretskyi <ihor@linux.com>