### PR TITLE
chore: modernize to Kubeflow 26.03 baseline, add stale PR cleanup

### DIFF
--- a/.github/workflows/stale-pr-cleanup.yml
+++ b/.github/workflows/stale-pr-cleanup.yml
@@ -1,0 +1,41 @@
+name: Stale PR Cleanup
+
+on:
+  schedule:
+    - cron: '0 1 * * *' # daily at 01:00 UTC
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  stale:
+    name: Mark and close stale PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Mark and close stale pull requests
+        uses: actions/stale@v9
+        with:
+          # Pull request staleness settings
+          days-before-pr-stale: 45
+          days-before-pr-close: 7
+          stale-pr-label: 'stale'
+          stale-pr-message: >
+            This pull request has had no activity for 45 days and is being marked
+            as stale. It will be closed automatically in 7 days unless there is
+            new activity. If this PR is still relevant, please leave a comment or
+            push an update to keep it open.
+          close-pr-message: >
+            This pull request has been closed due to inactivity. If the change is
+            still needed, please feel free to reopen this PR or create a new one.
+
+          # Disable issue staleness handling entirely
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # Operational limits
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          exempt-pr-labels: 'pinned,security,do-not-close'

--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ MIT License. See [LICENSE](LICENSE) for details.
 ## Repository Automation
 
 - **CI**: Python syntax check, Terraform fmt/validate, and required-files checks run on every push and pull request.
-- **Dependabot**: Automated dependency updates for GitHub Actions and pip packages, with auto-approve for minor/patch bumps.
+- **Dependabot**: Automated dependency updates for Terraform providers, GitHub Actions, and pip packages, with auto-approve for minor/patch bumps.
 - **Stale PR cleanup**: Pull requests with no activity for 45 days are automatically marked stale; they are closed after a further 7 days. Issues are not affected. The workflow runs daily and can also be triggered manually (`workflow_dispatch`). See [`.github/workflows/stale-pr-cleanup.yml`](.github/workflows/stale-pr-cleanup.yml).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubeflow on GKE
 
-Deploy a production-ready Kubeflow 1.11.0 environment on Google Kubernetes Engine using Terraform. This setup is cost-optimized using Spot VMs and GKE autoscaling.
+Deploy a production-ready Kubeflow 26.03 baseline environment on Google Kubernetes Engine using Terraform. This setup is cost-optimized using Spot VMs and GKE autoscaling.
 
 ## Quick Start
 
@@ -27,8 +27,8 @@ Deploy a production-ready Kubeflow 1.11.0 environment on Google Kubernetes Engin
 
 ## Infrastructure
 - **GKE Cluster**: Zonal cluster with Spot VMs and 1-10 nodes autoscaling.
-- **Kubeflow 1.11.0**: Includes Jupyter, Pipelines, Katib, and KServe.
-- **Service Mesh**: Istio 1.28.0 and cert-manager 1.16.1.
+- **Kubeflow 26.03 baseline**: Includes Jupyter, Pipelines, Katib, and KServe.
+- **Service Mesh**: Istio 1.29.0 and cert-manager 1.19.4.
 - **Security**: Private nodes, Workload Identity, and shielded nodes.
 - **Cost**: Estimated $30-100/month (60-91% savings vs on-demand).
 
@@ -84,3 +84,9 @@ terraform destroy
 
 ## License
 MIT License. See [LICENSE](LICENSE) for details.
+
+## Repository Automation
+
+- **CI**: Python syntax check, Terraform fmt/validate, and required-files checks run on every push and pull request.
+- **Dependabot**: Automated dependency updates for GitHub Actions and pip packages, with auto-approve for minor/patch bumps.
+- **Stale PR cleanup**: Pull requests with no activity for 45 days are automatically marked stale; they are closed after a further 7 days. Issues are not affected. The workflow runs daily and can also be triggered manually (`workflow_dispatch`). See [`.github/workflows/stale-pr-cleanup.yml`](.github/workflows/stale-pr-cleanup.yml).

--- a/examples/sample-ml-app/requirements.txt
+++ b/examples/sample-ml-app/requirements.txt
@@ -1,4 +1,4 @@
-kfp==2.15.2
+kfp==2.16.0
 pandas==3.0.0
 scikit-learn==1.8.0
 numpy==2.4.2

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,8 +60,6 @@ module "gke" {
   gpu_count        = var.gpu_count
   gpu_machine_type = var.gpu_machine_type
 
-  # Master authorized networks configuration
-  master_authorized_networks = []
 }
 module "kubeflow" {
   source       = "./modules/kubeflow"

--- a/terraform/modules/kubeflow/main.tf
+++ b/terraform/modules/kubeflow/main.tf
@@ -1,5 +1,5 @@
 locals {
-  kubeflow_version  = "1.11.0"
+  kubeflow_version  = "26.03"
   kustomize_version = "5.0.1"
 }
 # Create namespace for Kubeflow
@@ -33,7 +33,7 @@ resource "helm_release" "cert_manager" {
   name       = "cert-manager"
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = "v1.16.1"
+  version    = "v1.19.4"
   namespace  = kubernetes_namespace_v1.cert_manager.metadata[0].name
   set = [
     {
@@ -52,7 +52,7 @@ resource "helm_release" "istio_base" {
   name       = "istio-base"
   repository = "https://istio-release.storage.googleapis.com/charts"
   chart      = "base"
-  version    = "1.28.0"
+  version    = "1.29.0"
   namespace  = kubernetes_namespace_v1.istio_system.metadata[0].name
   depends_on = [kubernetes_namespace_v1.istio_system]
 }
@@ -60,7 +60,7 @@ resource "helm_release" "istiod" {
   name       = "istiod"
   repository = "https://istio-release.storage.googleapis.com/charts"
   chart      = "istiod"
-  version    = "1.28.0"
+  version    = "1.29.0"
   namespace  = kubernetes_namespace_v1.istio_system.metadata[0].name
   depends_on = [helm_release.istio_base]
 }

--- a/terraform/modules/kubeflow/manifests/kubeflow-core.yaml
+++ b/terraform/modules/kubeflow/manifests/kubeflow-core.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: kubeflow
   labels:
     app.kubernetes.io/name: centraldashboard
-    app.kubernetes.io/version: "1.11.0"
+    app.kubernetes.io/version: "26.03"
 spec:
   replicas: 1
   selector:
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: centraldashboard
       containers:
       - name: centraldashboard
-        image: kubeflownotebookswg/centraldashboard:v1.11.0
+        image: kubeflownotebookswg/centraldashboard:v26.03
         ports:
         - containerPort: 8082
         env:
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
       - name: manager
-        image: kubeflownotebookswg/profile-controller:v1.11.0
+        image: kubeflownotebookswg/profile-controller:v26.03
         ports:
         - containerPort: 8080
         env:

--- a/terraform/modules/kubeflow/manifests/kubeflow-notebook.yaml
+++ b/terraform/modules/kubeflow/manifests/kubeflow-notebook.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: notebook-controller
       containers:
       - name: manager
-        image: kubeflownotebookswg/notebook-controller:v1.11.0
+        image: kubeflownotebookswg/notebook-controller:v26.03
         ports:
         - containerPort: 8443
         env:
@@ -74,7 +74,7 @@ spec:
     spec:
       containers:
       - name: jupyter-web-app
-        image: kubeflownotebookswg/jupyter-web-app:v1.11.0
+        image: kubeflownotebookswg/jupyter-web-app:v26.03
         ports:
         - containerPort: 5000
         env:

--- a/terraform/modules/kubeflow/manifests/kubeflow-pipeline.yaml
+++ b/terraform/modules/kubeflow/manifests/kubeflow-pipeline.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: ml-pipeline
       containers:
       - name: ml-pipeline-api-server
-        image: gcr.io/ml-pipeline/api-server:2.15.0
+        image: gcr.io/ml-pipeline/api-server:2.16.0
         ports:
         - containerPort: 8888
         - containerPort: 8887
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
       - name: ml-pipeline-ui
-        image: gcr.io/ml-pipeline/frontend:2.15.0
+        image: gcr.io/ml-pipeline/frontend:2.16.0
         ports:
         - containerPort: 3000
         env:

--- a/terraform/modules/kubeflow/manifests/kubeflow-serving.yaml
+++ b/terraform/modules/kubeflow/manifests/kubeflow-serving.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: kfserving-controller
       containers:
       - name: manager
-        image: kserve/kserve-controller:v0.15.2
+        image: kserve/kserve-controller:v0.16.0
         ports:
         - containerPort: 8080
         env:
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
       - name: models-web-app
-        image: kubeflownotebookswg/models-web-app:v0.15.0
+        image: kubeflownotebookswg/models-web-app:v0.16.1
         ports:
         - containerPort: 5000
         env:


### PR DESCRIPTION
## Summary

Focused modernization update aligning the repository with the Kubeflow 26.03 baseline.

### Version bumps
| Component | Before | After |
|-----------|--------|-------|
| Kubeflow baseline | 1.11.0 | **26.03** |
| cert-manager (Helm) | v1.16.1 | **v1.19.4** |
| Istio base + istiod (Helm) | 1.28.0 | **1.29.0** |
| ml-pipeline/api-server | 2.15.0 | **2.16.0** |
| ml-pipeline/frontend | 2.15.0 | **2.16.0** |
| kserve/kserve-controller | v0.15.2 | **v0.16.0** |
| models-web-app | v0.15.0 | **v0.16.1** |
| kfp (requirements.txt) | 2.15.2 | **2.16.0** |

### Bug fix (pre-existing)
`terraform/main.tf` had a duplicate `master_authorized_networks` argument in the `module "gke"` block (introduced in #54). Both `terraform fmt -check` and `terraform validate` have been failing on `main` since that merge. The redundant literal `= []` assignment (line 64) has been removed, keeping the variable-based assignment.

### New workflow
`.github/workflows/stale-pr-cleanup.yml` — uses `actions/stale@v9`:
- PRs marked stale after **45 days** of inactivity
- Stale PRs closed after **7 additional days**
- Issues: staleness handling **disabled** (`-1`)
- Triggers: daily cron (01:00 UTC) + `workflow_dispatch`

### Documentation
`README.md` updated: version references reflect 26.03 baseline, Istio 1.29.0, cert-manager 1.19.4; new *Repository Automation* section documents CI, Dependabot, and stale-PR cleanup.

---

### Validation results (local, Terraform 1.12.2)
```
python3 -m py_compile pipeline.py data_generator.py run_pipeline.py  ✓
terraform fmt -check -recursive                                        ✓
terraform init -backend=false                                          ✓
terraform validate                                                     ✓
```